### PR TITLE
Correct typo in documentation example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ None
     autossh_tunnel_client_key_map:
       - src: ../../../files/autossh-tunnel-client/etc/autossh/id_rsa
     autossh_tunnel_client_host: 'example.com'
-    autossh_tunnel_client_forward: '[3307:127.0.0.1:3306]'
+    autossh_tunnel_client_forward: ['3307:127.0.0.1:3306']
 ```
 
 You will be able to connect to mysql using:


### PR DESCRIPTION
The value before was treated as a string which resulted in
syntactically valid (so no errors reported by autossh) invocation:

    /usr/lib/autossh/autossh -M 0 -4 -N -L [ -L 3 -L 3 -L 0 -L 7 -L ...

instead of:

    /usr/lib/autossh/autossh -M 0 -4 -N -L 3307:127.0.0.1:3306 ...

The documentation above the example did not have this typo.

fixes Oefenweb/ansible-autossh-tunnel-client#4