### PR TITLE
Allow content of SSH key to be defined through a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ None
 * `autossh_tunnel_client_autossh_poll`: [default: `60`]: Specifies the connection poll time in seconds
 
 * `autossh_tunnel_client_key_map`: [default: `[]`]: SSH key declarations
-* `autossh_tunnel_client_key_map.{n}.src`: [required]: The local path of the file to copy, can be absolute or relative (e.g. `../../../files/autossh-tunnel-client/etc/autossh/id_rsa`)
+* `autossh_tunnel_client_key_map.{n}.src`: [optional]: The path of the file to copy, can be absolute or relative (e.g. `../../../files/autossh-tunnel-client/etc/autossh/id_rsa`)
+* `autossh_tunnel_client_key_map.{n}.remote_src`: [optional, default `false`]: Whether the `src` is on the remote
 * `autossh_tunnel_client_key_map.{n}.dest`: [optional, default `src | basename`]: The remote path of the file to copy, relative to `/etc/autossh` (e.g. `id_rsa`)
 * `autossh_tunnel_client_key_map.{n}.owner`: [optional, default `root`]: The name of the user that should own the file
 * `autossh_tunnel_client_key_map.{n}.group`: [optional, default `owner`, `root`]: The name of the group that should own the file

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ None
 * `autossh_tunnel_client_autossh_pidfile`: [default: `/var/run/autossh/autossh-tunnel-client.pid`]: Write pid to specified file
 * `autossh_tunnel_client_autossh_poll`: [default: `60`]: Specifies the connection poll time in seconds
 
-* `autossh_tunnel_client_key_map`: [default: `[]`]: SSH key declarations
+* `autossh_tunnel_client_key_map`: [default: `[]`]: SSH key declarations. Each requires either `src` or `content` to be set (mutually exclusive)
 * `autossh_tunnel_client_key_map.{n}.src`: [optional]: The path of the file to copy, can be absolute or relative (e.g. `../../../files/autossh-tunnel-client/etc/autossh/id_rsa`)
 * `autossh_tunnel_client_key_map.{n}.remote_src`: [optional, default `false`]: Whether the `src` is on the remote
+* `autossh_tunnel_client_key_map.{n}.content`: [optional]: The key content. Must be used with `dest`
 * `autossh_tunnel_client_key_map.{n}.dest`: [optional, default `src | basename`]: The remote path of the file to copy, relative to `/etc/autossh` (e.g. `id_rsa`)
 * `autossh_tunnel_client_key_map.{n}.owner`: [optional, default `root`]: The name of the user that should own the file
 * `autossh_tunnel_client_key_map.{n}.group`: [optional, default `owner`, `root`]: The name of the group that should own the file

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -36,8 +36,9 @@
 
 - name: configure | copy key file(s)
   ansible.builtin.copy:
-    src: "{{ item.src }}"
+    src: "{{ item.src | default(omit) }}"
     remote_src: "{{ item.remote_src | default(omit) }}"
+    content: "{{ item.content | default(omit) }}"
     dest: "{{ autossh_tunnel_client_configuration_directory }}/{{ item.dest | default(item.src | basename) }}"
     owner: "{{ item.owner | default('root') }}"
     group: "{{ item.group | default(item.owner) | default('root') }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -39,7 +39,8 @@
     src: "{{ item.src | default(omit) }}"
     remote_src: "{{ item.remote_src | default(omit) }}"
     content: "{{ item.content | default(omit) }}"
-    dest: "{{ autossh_tunnel_client_configuration_directory }}/{{ item.dest | default(item.src | basename) }}"
+    # Even when `item.dest` is defined, the argument for the alternative default is evaluated so needs to not fail when `item.src` is not defined
+    dest: "{{ autossh_tunnel_client_configuration_directory }}/{{ item.dest | default(item.src | default('id_rsa') | basename) }}"
     owner: "{{ item.owner | default('root') }}"
     group: "{{ item.group | default(item.owner) | default('root') }}"
     mode: "{{ item.mode | default('0600') }}"


### PR DESCRIPTION
Currently, the role requires the SSH key to either be pre-written to a file on the control node, or on the remote host. This change allows the key content to be set through a variable (e.g. from a vault).

Also documents the ability to set `remote_src` for a key entry. 